### PR TITLE
nemo-compare: Fix error

### DIFF
--- a/nemo-compare/src/nemo-compare.py
+++ b/nemo-compare/src/nemo-compare.py
@@ -163,4 +163,4 @@ class NemoCompareExtension(GObject.GObject, Nemo.MenuProvider, Nemo.NameAndDescP
 		return []
 
 	def get_name_and_desc(self):
-		return [_("Nemo Compare:::Allows file comparison from the context menu")]
+		return [("Nemo Compare:::Allows file comparison from the context menu")]


### PR DESCRIPTION
  File "/usr/share/nemo-python/extensions/nemo-compare.py", line 166, in get_name_and_desc
    return [_("Nemo Compare:::Allows file comparison from the context menu")]
NameError: global name '_' is not defined